### PR TITLE
Update installer.py

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -47,7 +47,7 @@ args = Dot({
 })
 git_commit = "unknown"
 submodules_commit = {
-    # 'sd-webui-controlnet': 'ecd33eb',
+    'sd-webui-controlnet': 'ecd33eb',
     # 'stable-diffusion-webui-images-browser': '27fe4a7',
 }
 


### PR DESCRIPTION
Locking ControlNet extension at ecd33eb again to resolve current run preprocessor issues.

## Description

A clear and concise description of what you're trying to accomplish with this, so your intent doesn't have to be extracted from your code

## Notes

More technical discussion about your changes go here, plus anything that a maintainer might have to specifically take a look at, or be wary of

## Environment and Testing

List the environment you have developed / tested this on
